### PR TITLE
Adapt ImageNet to DataPipe style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,13 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# macOS dir files
+.DS_Store
+
+# Editor temporaries
+*.swn
+*.swo
+*.swp
+*.swm
+*~


### PR DESCRIPTION
There are two options to change `ImageNet` into DataPipe style
- Get `ImageNet` inherited from `IterDataPipe`
- Use existing `DataPipe` to create the data pipeline

The second approach is chosen because we want to re-use `DataPipe` from main repo as much as possible. Detail:
- Remove `find` to reduce loop through meta twice
- Change ImageNet to a function that returns a stacked `DataPipe`.